### PR TITLE
XHR: Stringify body if object is given

### DIFF
--- a/spec/resources.js
+++ b/spec/resources.js
@@ -55,6 +55,11 @@ var resources = {
     "name": "getJSONData4",
     "params": []
   }],
+  "/test/json5": [{
+    "verb": "POST",
+    "name": "postJSONData",
+    "params": []
+  }],
   "/test/xml": [{
     "verb": "GET",
     "name": "getXMLData",

--- a/spec/test-server.js
+++ b/spec/test-server.js
@@ -1,6 +1,7 @@
 var http = require("http");
 var express = require("express");
 var textBody = require("body");
+var jsonBody = require("body/json");
 var Bacon = require("baconjs");
 
 var app = express();
@@ -58,6 +59,18 @@ app.get("/test/json3", function(req, res) {
 app.get("/test/json4", function(req, res){
   res.setHeader("Content-Type", "application/json");
   res.send("{'a':'1', 'b'");
+});
+
+app.post("/test/json5", function(req, res){
+  jsonBody(req, function(err, body){
+    if(err){
+      res.status(500).end();
+    } else{
+      res.json({
+        type: typeof body
+      });
+    }
+  });
 });
 
 app.get("/test/xml", function(req, res) {

--- a/spec/wadl-client.spec.js
+++ b/spec/wadl-client.spec.js
@@ -52,7 +52,7 @@ describe("wadl-client", function() {
 
   it("should be able to download resources by giving specific header at sending time", function(done) {
     var res = client.test.private.get().withHeaders({
-        Authorization: "12345"
+      Authorization: "12345"
     }).send();
 
     res.onValue(function(data) {
@@ -151,6 +151,19 @@ describe("wadl-client", function() {
       done();
     });
   });
+
+  it("must not throw an 'Argument error, options.body' if body is an object", function(done){
+    var body = {
+      json: true
+    };
+    var res = client.test.json5.post().withParsing().send(body);
+
+    res.onValue(function(data){
+      expect(data.type).toBe("object");
+      done();
+    });
+  });
+
 
   it("must send an error on timeout", function(done) {
     var res = client.test.timeout.get().withTimeout(2000).send();

--- a/wadl-client.js
+++ b/wadl-client.js
@@ -159,7 +159,7 @@ var WadlClient = (function() {
           qs: req.query,
           parse: req.parse,
           timeout: req.timeout,
-          body: body
+          body: typeof body === "object" ? JSON.stringify(body) : body
         });
       };
 


### PR DESCRIPTION
If object was given to .send(), sendNodeRequest() would crash with error "Argument error, options.body" and sendBrowserRequest() would send a string "[object object]" instead of the object