### PR TITLE
Specify null if body of XHR request is undefined (IE fix)

### DIFF
--- a/wadl-client.js
+++ b/wadl-client.js
@@ -161,7 +161,7 @@ var WadlClient = (function() {
       }
     }
 
-    xhr.send(options.body);
+    xhr.send(options.body || null);
 
     return result;
   };


### PR DESCRIPTION
Internet explorer sends "undefined" as a body if it gets an undefined body as a parameter for xhr.send()

For IE:
```
xhr.send(undefined) = xhr.send("undefined")
```